### PR TITLE
WIP: add kwarg to accept new tune points, rather than remap onto the old

### DIFF
--- a/attune/workup/_tune_test.py
+++ b/attune/workup/_tune_test.py
@@ -11,6 +11,7 @@ from ._plot import plot_tune_test
 
 __all__ = ["tune_test"]
 
+
 def _offsets(data, channel_name, tune_points, *, spline=True, **spline_kwargs):
     data.moment(axis=1, channel=channel_name, moment=1)
     offsets = data[f"{channel_name}_1_moment_1"].points
@@ -25,7 +26,16 @@ def _offsets(data, channel_name, tune_points, *, spline=True, **spline_kwargs):
 
 
 def tune_test(
-    data, channel, curve=None, *, level=False, gtol=0.01, ltol=0.1, autosave=True, save_directory=None
+    data,
+    channel,
+    curve=None,
+    *,
+    level=False,
+    gtol=0.01,
+    ltol=0.1,
+    map_points=True,
+    autosave=True,
+    save_directory=None,
 ):
     """Workup a Tune Test.
 
@@ -43,6 +53,8 @@ def tune_test(
         global tolerance for rejecting noise level relative to global maximum
     ltol: float, optional
         local tolerance for rejecting data relative to slice maximum
+    map_points: bool, optional
+        remap points onto the original setpoints (Defaults to True)
     autosave: bool, optional
         toggles saving of curve file and images (Defaults to True)
     save_directory: Path-like
@@ -66,7 +78,9 @@ def tune_test(
 
     if isinstance(channel, (int, str)):
         channel = data.channels[wt.kit.get_index(data.channel_names, channel)]
-        orig_channel = data.create_channel(f"{channel.natural_name}_orig", channel, units=channel.units)
+        orig_channel = data.create_channel(
+            f"{channel.natural_name}_orig", channel, units=channel.units
+        )
 
     # TODO: check if level does what we want
     if level:
@@ -92,9 +106,12 @@ def tune_test(
 
     # plot ----------------------------------------------------------------------------------------
 
-    fig, _ = plot_tune_test(data, channel.natural_name, new_curve, prior_curve=old_curve, raw_offsets=raw_offsets)
+    fig, _ = plot_tune_test(
+        data, channel.natural_name, new_curve, prior_curve=old_curve, raw_offsets=raw_offsets
+    )
 
-    new_curve.map_setpoints(setpoints[:], units=setpoints.units)
+    if map_points:
+        new_curve.map_setpoints(setpoints[:], units=setpoints.units)
     new_curve.convert(curve.setpoints.units)
     data.axes[0].convert(curve.setpoints.units)
     # finish --------------------------------------------------------------------------------------


### PR DESCRIPTION
Closes #60

![tune_test](https://user-images.githubusercontent.com/2501846/63889410-90a50a00-c9a6-11e9-9ac3-8b7fa9dff650.png)
Here is a tune test taken on the PS table recently

This revealed two main deficiencies:

1) Our plotting seems to be doing something different than what we thought
    I've suspected as much in the past, but never saw it bad enough to be sure

2) When the colors are particularly far off (as with this where both ends of the curve were well off from the appropriate colors), we may actually want to _accept_ the colors that the procedure fits, rather than remapping onto the original setpoints.

This PR deals with the latter, adding a simple boolean kwarg which defaults to true, but if set to false will avoid remapping


Doing so will lead to changing your curve tuning range, and is not reccommended in most cases, except where you are not confident in what the tuning range should actually be