### PR TITLE
Add rename_dependent function

### DIFF
--- a/attune/curve/_base.py
+++ b/attune/curve/_base.py
@@ -480,6 +480,17 @@ class Curve:
             plt.savefig(image_path, transparent=True, dpi=300)
             plt.close(fig)
 
+    def rename_dependent(self, old_name, new_name):
+        old_dependent = self.dependents[old_name]
+        new_dependent = Dependent(
+            old_dependent.positions, new_name, old_dependent.units, old_dependent.differential, old_dependent.index
+        )
+        delattr(self, old_name)
+        setattr(self, new_name, new_dependent)
+        del self.dependents[old_name]
+        self.dependents[new_name] = new_dependent
+        self.interpolate()
+
     @classmethod
     def read(cls, filepath, subcurve=None):
         filepath = pathlib.Path(filepath)

--- a/attune/curve/_base.py
+++ b/attune/curve/_base.py
@@ -483,7 +483,11 @@ class Curve:
     def rename_dependent(self, old_name, new_name):
         old_dependent = self.dependents[old_name]
         new_dependent = Dependent(
-            old_dependent.positions, new_name, old_dependent.units, old_dependent.differential, old_dependent.index
+            old_dependent.positions,
+            new_name,
+            old_dependent.units,
+            old_dependent.differential,
+            old_dependent.index,
         )
         delattr(self, old_name)
         setattr(self, new_name, new_dependent)

--- a/attune/curve/_base.py
+++ b/attune/curve/_base.py
@@ -481,18 +481,14 @@ class Curve:
             plt.close(fig)
 
     def rename_dependent(self, old_name, new_name):
-        old_dependent = self.dependents[old_name]
-        new_dependent = Dependent(
-            old_dependent.positions,
-            new_name,
-            old_dependent.units,
-            old_dependent.differential,
-            old_dependent.index,
-        )
+        try:
+            dep = self.dependents[old_name]
+        except KeyError:
+            raise ValueError(f"Dependent '{old_name}' not found")
+        dep.name = new_name
         delattr(self, old_name)
-        setattr(self, new_name, new_dependent)
-        del self.dependents[old_name]
-        self.dependents[new_name] = new_dependent
+        setattr(self, new_name, dep)
+        self.dependents = {k if k != old_name else new_name: v for k, v in self.dependents.items()}
         self.interpolate()
 
     @classmethod

--- a/tests/Curve/rename.py
+++ b/tests/Curve/rename.py
@@ -1,0 +1,25 @@
+import attune
+import numpy as np
+import pytest
+
+
+def test_rename():
+    d = attune.Dependent(np.linspace(0, 10, 21), "d1")
+    s = attune.Setpoints(np.linspace(120, 240, 21), "s1")
+    c = attune.Curve(s, d, "c")
+
+    c.rename_dependent("d1", "d2")
+
+    assert "d2" in c.dependents
+    assert "d1" not in c.dependents
+    assert np.allclose(c["d2"][:], d[:])
+    assert c["d2"].name == "d2"
+
+
+def test_rename_not_present():
+    d = attune.Dependent(np.linspace(0, 10, 21), "d1")
+    s = attune.Setpoints(np.linspace(120, 240, 21), "s1")
+    c = attune.Curve(s, d, "c")
+
+    with pytest.raises(ValueError):
+        c.rename_dependent("d2", "d1")


### PR DESCRIPTION
Semi related to #44 

Looking back, I'm not sure why I felt I needed to create a new object...

If desired, I can update this to do dictionary manipulation, attr changing, and changing of the field in the underlying object only.

The other thing that may be desired is to preserve the original order, thus making the dictionary manipulation something like 

```python
self.dependents = {k:v if k != old_name else new_name: v for k,v in self.dependents.items()}
```

Additionally, there should be some tests of this behavior.

I think in writing this out, I've convinced myself that these changes are desiriable... 