### PR TITLE
Tweak units in workup procedures

### DIFF
--- a/attune/workup/_holistic.py
+++ b/attune/workup/_holistic.py
@@ -98,6 +98,7 @@ def holistic(
             spectral_axis = data.axis_names[spectral_axis]
         elif isinstance(spectral_axis, wt.data.Axis):
             spectral_axis = spectral_axis.expression
+        getattr(data, spectral_axis).convert(curve.setpoints.units)
         # take channel moments
         data.moment(
             axis=spectral_axis,

--- a/attune/workup/_plot.py
+++ b/attune/workup/_plot.py
@@ -157,7 +157,7 @@ def plot_holistic(
     ax_amp.contour(
         data,
         channel=center_channel,
-        levels=center_ticks,
+        levels=sorted(center_ticks),
         cmap=center_cmap,
         linewidths=2,
         alpha=1,

--- a/attune/workup/_setpoint.py
+++ b/attune/workup/_setpoint.py
@@ -66,10 +66,10 @@ def setpoint(
         New curve object.
     """
     data = data.copy()
-    data.convert("wn")
+    # data.convert("wn")
     if curve is not None:
         old_curve = curve.copy()
-        old_curve.convert("wn")
+        # old_curve.convert("wn")
         setpoints = old_curve.setpoints
     else:
         old_curve = None

--- a/tests/workup/setpoint/2018-11-30/aixcb.py
+++ b/tests/workup/setpoint/2018-11-30/aixcb.py
@@ -25,6 +25,9 @@ def test():
 
     old = attune.TopasCurve.read([__here__ / "old.crv"], interaction_string="NON-NON-NON-Sig")
 
+    data.convert("wn")
+    old.convert("wn")
+
     new = attune.workup.setpoint(data, -1, "2", autosave=False, curve=old)
 
     print(new)


### PR DESCRIPTION
These are tweaks I added as part of making the workup procedures run on the fs table.

I need to think a bit on whether some of these changes should be reverted/better handled

There are some plotting inconsistencies I think need to be tracked down, probably due to units.

This plays a bit into #38, and maybe the solution is "Make sure we _always_ cast to wavenumbers" for now (which is _not_ what this PR currently accomplishes)