### PR TITLE
Fix saving of Sig and Idl curves tied together

### DIFF
--- a/attune/curve/_topas.py
+++ b/attune/curve/_topas.py
@@ -181,6 +181,7 @@ class TopasCurve(Curve):
             to_insert["NON-NON-NON-Idl"] = _convert(curve)
             to_insert["NON-NON-NON-Idl"].interaction = "NON-NON-NON-Idl"
 
+
         # get save directory
         if save_directory is None:
             save_directory = pathlib.Path()
@@ -198,7 +199,7 @@ class TopasCurve(Curve):
             self.plot(autosave=True, save_path=image_path, title=title)
 
         while len(to_insert):
-            _, curve = to_insert.popitem()
+            curve = to_insert[list(to_insert.keys())[0]]
             out_name = curve.kind + "- " + timestamp
             out_path = (save_directory / out_name).with_suffix(".crv")
             all_sibs = [curve]
@@ -209,8 +210,8 @@ class TopasCurve(Curve):
                 _write_headers(new_crv, curve)
                 new_crv.write(f"{len(all_sibs)}\n")
                 for c in all_sibs:
+                    c = to_insert.pop(c.interaction, c)
                     _write_curve(new_crv, c)
-                    to_insert.pop(c.interaction, None)
                 if verbose:
                     print("curve saved at", out_path)
 

--- a/attune/curve/_topas.py
+++ b/attune/curve/_topas.py
@@ -181,7 +181,6 @@ class TopasCurve(Curve):
             to_insert["NON-NON-NON-Idl"] = _convert(curve)
             to_insert["NON-NON-NON-Idl"].interaction = "NON-NON-NON-Idl"
 
-
         # get save directory
         if save_directory is None:
             save_directory = pathlib.Path()

--- a/tests/TopasCurve/read/2018-10-26/niuce.py
+++ b/tests/TopasCurve/read/2018-10-26/niuce.py
@@ -37,6 +37,19 @@ def test_round_trip():
         for d1, d2 in zip(curve.dependents, read_curve.dependents):
             assert np.allclose(curve[d1][:], read_curve[d2][:])
 
+def test_sig_idl_saved_relationship():
+    paths = [__here__ / "OPA1 (10743) base - 2018-10-26 40490.crv"]
+    curve = attune.TopasCurve.read(paths, interaction_string="NON-NON-NON-Sig")
+    curve.dependents["1"][:] += 1
+    with tempfile.TemporaryDirectory() as td:
+        td = pathlib.Path(td)
+        curve.save(save_directory=td, full=True)
+        paths = td.glob("*.crv")
+        read_curve = attune.TopasCurve.read(paths, interaction_string="NON-NON-NON-Idl")
+        assert np.allclose(curve.dependents["1"][:], read_curve.dependents["1"][::-1])
+        assert curve.dependent_names == read_curve.dependent_names
+
+
 
 if __name__ == "__main__":
     test_is_instance()

--- a/tests/TopasCurve/read/2018-10-26/niuce.py
+++ b/tests/TopasCurve/read/2018-10-26/niuce.py
@@ -37,6 +37,7 @@ def test_round_trip():
         for d1, d2 in zip(curve.dependents, read_curve.dependents):
             assert np.allclose(curve[d1][:], read_curve[d2][:])
 
+
 def test_sig_idl_saved_relationship():
     paths = [__here__ / "OPA1 (10743) base - 2018-10-26 40490.crv"]
     curve = attune.TopasCurve.read(paths, interaction_string="NON-NON-NON-Sig")
@@ -48,7 +49,6 @@ def test_sig_idl_saved_relationship():
         read_curve = attune.TopasCurve.read(paths, interaction_string="NON-NON-NON-Idl")
         assert np.allclose(curve.dependents["1"][:], read_curve.dependents["1"][::-1])
         assert curve.dependent_names == read_curve.dependent_names
-
 
 
 if __name__ == "__main__":

--- a/tests/workup/intensity/2018-11-30/qgnsm.py
+++ b/tests/workup/intensity/2018-11-30/qgnsm.py
@@ -14,7 +14,7 @@ def test():
     data.moment("wa_points", moment=0)
     data.transform("w1=wm", "w1_Delay_2_points")
     old = attune.TopasCurve.read([__here__ / "old.crv"], interaction_string="NON-NON-NON-Sig")
-    new = attune.workup.intensity(data, -1, "3", curve=old)
+    new = attune.workup.intensity(data, -1, "3", autosave=False, curve=old)
     print(new)
 
 


### PR DESCRIPTION
This was a confluence of small errors, which resulted in the _old_ sibling curve being written, not the newly computed one...

This was the way I found that it worked, but there may be a cleaner route...