### PR TITLE
Make instantiating from nested dictionaries work natively

### DIFF
--- a/attune/_arrangement.py
+++ b/attune/_arrangement.py
@@ -6,7 +6,7 @@ from ._tune import Tune
 
 
 class Arrangement:
-    def __init__(self, name: str, tunes: Dict[str, Tune]):
+    def __init__(self, name: str, tunes: Dict[str, Union[Tune, dict]]):
         """Arrangement of several Tunes to form one cohesive set.
 
         Tunes may represent either motors or other arrangements, however
@@ -23,11 +23,13 @@ class Arrangement:
         tunes: Dict[str, Tune]
             Mapping of names to Tune objects which compose the Arrangement
         """
-        self._name = name
-        self._tunes = tunes
-        self._ind_units = "nm"
-        self._ind_max = min([t.ind_max for t in self._tunes.values()])
-        self._ind_min = max([t.ind_min for t in self._tunes.values()])
+        self._name: str = name
+        self._tunes: Dict[str, Tune] = {
+            k: Tune(**v) if isinstance(v, dict) else v for k, v in tunes.items()
+        }
+        self._ind_units: str = "nm"
+        self._ind_max: float = min([t.ind_max for t in self._tunes.values()])
+        self._ind_min: float = max([t.ind_min for t in self._tunes.values()])
 
     def __repr__(self):
         return f"Arrangement({repr(self.name)}, {repr(self.tunes)})"

--- a/attune/_arrangement.py
+++ b/attune/_arrangement.py
@@ -1,7 +1,7 @@
 __all__ = ["Arrangement"]
 
 
-from typing import Dict
+from typing import Dict, Union
 from ._tune import Tune
 
 

--- a/attune/_instrument.py
+++ b/attune/_instrument.py
@@ -2,7 +2,7 @@ __all__ = ["Instrument"]
 
 
 from datetime import datetime as _datetime
-from typing import Dict
+from typing import Dict, Optional, Union
 import json
 
 from ._arrangement import Arrangement
@@ -12,15 +12,29 @@ from ._transition import Transition, TransitionType
 
 
 class Instrument(object):
-    def __init__(self, arrangements, setables, *, name=None, transition=None, load=None):
-        self._name: str = name
-        self._arrangements: Dict["str", Arrangement] = arrangements
-        self._setables: Dict["str", Setable] = setables
+    def __init__(
+        self,
+        arrangements: Dict["str", Union[Arrangement, dict]],
+        setables: Dict["str", Union[Setable, dict]],
+        *,
+        name: Optional[str] = None,
+        transition: Optional[Union[Transition, dict]] = None,
+        load: Optional[float] = None,
+    ):
+        self._name: Optional[str] = name
+        self._arrangements: Dict["str", Arrangement] = {
+            k: Arrangement(**v) if isinstance(v, dict) else v for k, v in arrangements.items()
+        }
+        self._setables: Dict["str", Setable] = {
+            k: Setable(**v) if isinstance(v, dict) else v for k, v in setables.items()
+        }
         if transition is None:
             self._transition = Transition(TransitionType.create)
+        elif isinstance(transition, dict):
+            self._transition = Transition(**transition)
         else:
             self._transition = transition
-        self._load = load
+        self._load: Optional[float] = load
 
     def __repr__(self):
         ret = f"Instrument({repr(self.arrangements)}, {repr(self.setables)}"

--- a/attune/_open.py
+++ b/attune/_open.py
@@ -34,19 +34,4 @@ def open(path, *, load=False):
         with open_(path, "r") as f:
             d = json.load(f)
 
-    arrangements = {}
-    for arrangement_name in d["arrangements"].keys():
-        tunes = {k: Tune(**v) for k, v in d["arrangements"][arrangement_name]["tunes"].items()}
-        arrangements[arrangement_name] = Arrangement(name=arrangement_name, tunes=tunes)
-
-    setables = {k: Setable(**v) for k, v in d["setables"].items()}
-
-    transition = Transition(**d["transition"])
-
-    return Instrument(
-        name=d["name"],
-        arrangements=arrangements,
-        setables=setables,
-        transition=transition,
-        load=load,
-    )
+    return Instrument(**d, load=load)

--- a/attune/_open.py
+++ b/attune/_open.py
@@ -2,11 +2,7 @@ __all__ = ["open"]
 
 import json
 
-from ._arrangement import Arrangement
 from ._instrument import Instrument
-from ._setable import Setable
-from ._transition import Transition
-from ._tune import Tune
 
 open_ = open
 


### PR DESCRIPTION
Filled out some mypy types in the signatures reflecting that they accept dicts, though did _not_ fully specify the contents of those dicts, as it gets nastily nested.... Not quite ready to pass mypy in full yet (and thus add to CI)

The touched files pass, but not other places where WT and such are imported.

Makes opening trivial, and also recieving over the wire in yaq