### PR TITLE
Update deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,8 @@ setup(
         "numpy",
         "scipy",
         "matplotlib",
-        "tidy_headers",
         "appdirs",
+        "python-dateutil",
         "maya",
     ],
     extras_require={


### PR DESCRIPTION
Not really that big a deal, just removing a transitive dependency that we don't import directly and vice versa... that said, transitive dependency does give us dateutil and tidy_headers in both cases, so not worth rereleasing

I did update the deps on conda