### PR TITLE
CodeQL identified error/warning changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+- Resolve some issues discovered by CodeQL which could result in unexpected behavior
+
 ## [0.4.3]
 
 ### Added

--- a/attune/_arrangement.py
+++ b/attune/_arrangement.py
@@ -63,7 +63,7 @@ class Arrangement:
         out = np.unique(
             np.concatenate([t.independent for t in self._tunes.values() if isinstance(t, Tune)], 0)
         )
-        tol = tol = 1e-3 * (self.ind_max - self.ind_min)
+        tol = 1e-3 * (self.ind_max - self.ind_min)
         diff = np.append(tol * 2, np.diff(out))
         out = out[diff > tol]
         out = out[out <= self.ind_max]

--- a/attune/_note.py
+++ b/attune/_note.py
@@ -39,7 +39,6 @@ class Note:
 
     def keys(self):
         """Settable keys in the Note."""
-        return self.setable_positions.items()
         return self.setable_positions.keys()
 
     def values(self):

--- a/attune/io/topas4.py
+++ b/attune/io/topas4.py
@@ -31,6 +31,8 @@ def from_topas4(topas4_folder):
         if a["GUID"] == opt_dev_active_guid:
             opt_dev_active = a["OpticalDevices"]
             break
+    else:
+        raise ValueError("Active optical device GUID not found")
 
     sep_dev_active_guid = sep_dev.get("ActiveConfigurationGUID")
     sep_dev_conf = sep_dev["Configurations"]
@@ -40,6 +42,8 @@ def from_topas4(topas4_folder):
         if a["GUID"] == sep_dev_active_guid:
             sep_dev_active = a["SeparationDevices"]
             break
+    else:
+        raise ValueError("Active separation device GUID not found")
 
     arrangements = {}
     setables = {}


### PR DESCRIPTION
These are the most serious code quality issues found, notably adding informative error messages and correcting an accidental double return

The remaining library code warnings are exclusively 'unused local variable', which should be looked at as they can be errors like #144 where we have a thought to use data and then fail to follow through